### PR TITLE
fix-Rsp1095

### DIFF
--- a/sbml/iFF708/exchange.yaml
+++ b/sbml/iFF708/exchange.yaml
@@ -1,316 +1,211 @@
 compounds:
 - id: m162
   reaction: ACALxtO
-  lower: 0.0
 - id: m172
   reaction: ACxtI
-  fixed: 0.0
 - id: m186
   reaction: ADNxtI
-  fixed: 0.0
 - id: m191
   reaction: ADxtO
-  lower: 0.0
 - id: m193
   reaction: AKGxtO
-  lower: 0.0
 - id: m195
   reaction: ALAxtO
-  lower: 0.0
 - id: m214
   reaction: AONAxtO
-  lower: 0.0
 - id: m215
   reaction: ARABxtO
-  lower: 0.0
 - id: m216
   reaction: ARGxtO
-  lower: 0.0
 - id: m217
   reaction: ASNxtI
-  fixed: 0.0
 - id: m218
   reaction: ASPxtI
-  fixed: 0.0
 - id: m219
   reaction: ATNxtI
-  fixed: 0.0
 - id: m232
   reaction: BMxtI
-  fixed: 0.0
 - id: m233
   reaction: BTxtO
-  lower: 0.0
 - id: m236
   reaction: C140xtO
-  lower: 0.0
 - id: m238
   reaction: C160xtO
-  lower: 0.0
 - id: m239
   reaction: C180xtI
-  fixed: 0.0
 - id: m259
   reaction: CHOxtI
-  fixed: 0.0
 - id: m262
   reaction: CITxtO
-  lower: 0.0
 - id: m267
   reaction: CO2xtI
-  fixed: 0.0
 - id: m274
   reaction: CYSxtI
-  fixed: 0.0
 - id: m275
   reaction: CYTDxtI
-  fixed: 0.0
 - id: m278
   reaction: CYTSxtO
-  lower: 0.0
 - id: m282
   reaction: DANNAxtI
-  fixed: 0.0
 - id: m286
   reaction: DAxtO
-  lower: 0.0
 - id: m290
   reaction: DCxtO
-  lower: 0.0
 - id: m321
   reaction: DGxtO
-  lower: 0.0
 - id: m329
   reaction: DINxtI
-  fixed: 0.0
 - id: m331
   reaction: DIPEPxtO
-  lower: 0.0
 - id: m352
   reaction: DTTPxtO
-  lower: 0.0
 - id: m353
   reaction: DTxtI
-  fixed: 0.0
 - id: m357
   reaction: DUxtI
-  fixed: 0.0
 - id: m366
   reaction: ERGOxtO
-  lower: 0.0
 - id: m371
   reaction: ETHxtI
-  fixed: 0.0
 - id: m383
   reaction: FORxtO
-  lower: 0.0
 - id: m384
   reaction: FRUxtO
-  lower: 0.0
 - id: m385
   reaction: FUCxtO
-  lower: 0.0
 - id: m388
   reaction: FUMxtI
-  fixed: 0.0
 - id: m389
   reaction: GA6PxtI
-  fixed: 0.0
 - id: m390
   reaction: GABAxtI
-  fixed: 0.0
 - id: m398
   reaction: GLACxtO
-  lower: 0.0
 - id: m399
   reaction: GLALxtI
-  fixed: 0.0
 - id: m400
   reaction: GLAMxtI
-  fixed: 0.0
 - id: m401
   reaction: GLCxtI
-  fixed: 0.0
 - id: m402
   reaction: GLNxtO
-  lower: 0.0
 - id: m403
   reaction: GLTxtO
-  lower: 0.0
 - id: m408
   reaction: GLUxtO
-  lower: 0.0
 - id: m409
   reaction: GLxtI
-  fixed: 0.0
 - id: m420
   reaction: GLYxtO
-  lower: 0.0
 - id: m422
   reaction: GNxtI
-  fixed: 0.0
 - id: m423
   reaction: GSNxtO
-  lower: 0.0
 - id: m437
   reaction: HISxtI
-  fixed: 0.0
 - id: m445
   reaction: HYXNxtO
-  lower: 0.0
 - id: m448
   reaction: ILExtI
-  fixed: 0.0
 - id: m457
   reaction: INSxtO
-  lower: 0.0
 - id: m469
   reaction: KxtI
-  fixed: 0.0
 - id: m474
   reaction: LACxtO
-  lower: 0.0
 - id: m489
   reaction: LEUxtI
-  fixed: 0.0
 - id: m532
   reaction: LYSxtO
-  lower: 0.0
 - id: m541
   reaction: MALxtI
-  fixed: 0.0
 - id: m544
   reaction: MANxtI
-  fixed: 0.0
 - id: m547
   reaction: MELIxtI
-  fixed: 0.0
 - id: m553
   reaction: METxtO
-  lower: 0.0
 - id: m554
   reaction: MIxtI
-  fixed: 0.0
 - id: m555
   reaction: MLTxtI
-  fixed: 0.0
 - id: m556
   reaction: MMETxtO
-  lower: 0.0
 - id: m557
   reaction: MNTxtO
-  lower: 0.0
 - id: m558
   reaction: MTHNxtO
-  lower: 0.0
 - id: m591
   reaction: NAxtI
-  fixed: 0.0
 - id: m596
   reaction: NH3xtO
-  lower: 0.0
 - id: m605
   reaction: NMNxtI
-  fixed: 0.0
 - id: m607
   reaction: O2xtO
-  lower: 0.0
 - id: m612
   reaction: OGTxtO
-  lower: 0.0
 - id: m616
   reaction: OPEPxtI
-  fixed: 0.0
 - id: m619
   reaction: ORNxtI
-  fixed: 0.0
 - id: m645
   reaction: PAPxtI
-  fixed: 0.0
 - id: m647
   reaction: PEPTxtO
-  lower: 0.0
 - id: m650
   reaction: PHExtO
-  lower: 0.0
 - id: m667
   reaction: PIMExtO
-  lower: 0.0
 - id: m668
   reaction: PIxtI
-  fixed: 0.0
 - id: m669
   reaction: PNTOxtO
-  lower: 0.0
 - id: m676
   reaction: PROxtI
-  fixed: 0.0
 - id: m692
   reaction: PYRxtI
-  fixed: 0.0
 - id: m697
   reaction: RFLAVxtO
-  lower: 0.0
 - id: m700
   reaction: RIBxtO
-  lower: 0.0
 - id: m702
   reaction: RMNxtO
-  lower: 0.0
 - id: m711
   reaction: SAMxtO
-  lower: 0.0
 - id: m714
   reaction: SERxtI
-  fixed: 0.0
 - id: m719
   reaction: SLFxtI
-  fixed: 0.0
 - id: m725
   reaction: SORxtI
-  fixed: 0.0
 - id: m731
   reaction: SPRMxtI
-  fixed: 0.0
 - id: m740
   reaction: SUCCxtI
-  fixed: 0.0
 - id: m742
   reaction: SUCxtI
-  fixed: 0.0
 - id: m757
   reaction: THMxtI
-  fixed: 0.0
 - id: m758
   reaction: THRxtO
-  lower: 0.0
 - id: m761
   reaction: THYxtI
-  fixed: 0.0
 - id: m764
   reaction: TRExtO
-  lower: 0.0
 - id: m772
   reaction: TRPxtO
-  lower: 0.0
 - id: m773
   reaction: TYRxtO
-  lower: 0.0
 - id: m782
   reaction: URAxtI
-  fixed: 0.0
 - id: m785
   reaction: UREAxtI
-  fixed: 0.0
 - id: m787
   reaction: URIxtI
-  fixed: 0.0
 - id: m790
   reaction: VALxtI
-  fixed: 0.0
 - id: m794
   reaction: XANxtO
-  lower: 0.0
 - id: m798
   reaction: ZYMSTxtI
-  fixed: 0.0

--- a/sbml/iRsp1095/exchange.yaml
+++ b/sbml/iRsp1095/exchange.yaml
@@ -4,13 +4,13 @@ compounds:
   lower: 0.0
 - id: CPD0730
   reaction: RXN0196
-  lower: 0.0
+  lower: -1000
 - id: CPD0732
   reaction: RXN0197
   lower: 0.0
 - id: CPD0734
   reaction: RXN1354
-  lower: 0.0
+  lower: -1000
 - id: CPD0736
   reaction: RXN0198
   lower: 0.0
@@ -55,7 +55,7 @@ compounds:
   lower: 0.0
 - id: CPD0771
   reaction: RXN0213
-  lower: 0.0
+  lower: -1000
 - id: CPD0773
   reaction: RXN0214
   lower: 0.0
@@ -112,7 +112,7 @@ compounds:
   lower: 0.0
 - id: CPD0829
   reaction: RXN0192
-  lower: 0.0
+  lower: -1000
 - id: CPD0832
   reaction: RXN0191
   lower: 0.0
@@ -127,7 +127,7 @@ compounds:
   lower: 0.0
 - id: CPD0875
   reaction: RXN0219
-  lower: 0.0
+  lower: -1000
 - id: CPD0878
   reaction: RXN0220
   lower: 0.0
@@ -139,7 +139,7 @@ compounds:
   lower: 0.0
 - id: CPD0885
   reaction: RXN0223
-  lower: 0.0
+  lower: -1000
 - id: CPD0887
   reaction: RXN0224
   lower: 0.0
@@ -193,7 +193,7 @@ compounds:
   lower: 0.0
 - id: CPD1074
   reaction: RXN1101
-  lower: 0.0
+  lower: -1000
 - id: CPD1076
   reaction: RXN1104
   lower: 0.0
@@ -247,7 +247,7 @@ compounds:
   lower: 0.0
 - id: CPD1114
   reaction: RXN1158
-  lower: 0.0
+  lower: -1000
 - id: CPD1116
   reaction: RXN1161
   lower: 0.0
@@ -382,10 +382,10 @@ compounds:
   lower: 0.0
 - id: CPD1211
   reaction: RXN1326
-  lower: 0.0
+  lower: -1000
 - id: CPD1213
   reaction: RXN1329
-  lower: 0.0
+  lower: -1000
 - id: CPD1214
   reaction: RXN1331
   lower: 0.0


### PR DESCRIPTION
Changes under the category iFF708: Allow exchange reactions, including:
(1) Allow essential compounds in medium
(2) made all lower exchange bounds zero
(3) Made lower bounds of required compounds for growth as stated in Imam et. al.