### PR TITLE
fix-ijn746

### DIFF
--- a/sbml/iJN746/reactions.yaml
+++ b/sbml/iJN746/reactions.yaml
@@ -1228,6 +1228,21 @@
     - id: val-L
       compartment: c
       value: 0.402
+    - id: clpn120
+      compartment: p
+      value: 0.0005
+    - id: clpn160
+      compartment: p
+      value: 0.0005
+    - id: clpn161
+      compartment: p
+      value: 0.0005
+    - id: clpn180
+      compartment: p
+      value: 0.0005
+    - id: clpn181
+      compartment: p
+      value: 0.0005
     right:
     - id: adp
       compartment: c


### PR DESCRIPTION
iJN746: Fixed mislabled cardiolipin (clpn) compounds in biomass equation