### PR TITLE
Remove empty reaction entries

### DIFF
--- a/sbml/PpaMBEL1254/reactions.yaml
+++ b/sbml/PpaMBEL1254/reactions.yaml
@@ -57,7 +57,6 @@
   equation: h_c[cell] + nadph_c[cell] + TRDox_c[cell] => nadp_c[cell] + TRDrd_c[cell]
 - id: R00032
   equation: a_13BDglcn_c[cell] + H2O_c[cell] => glcD_c[cell]
-- id: R00033
 - id: R00034
   equation: udpg_c[cell] => a_13BDglcn_c[cell] + h_c[cell] + udp_c[cell]
 - id: R00035
@@ -248,7 +247,6 @@
   equation: cit_m[cell] <=> icit_m[cell]
 - id: R00138
   equation: acg5sa_m[cell] + gluL_m[cell] => acorn_m[cell] + akg_m[cell]
-- id: R00139
 - id: R00140
   equation: acrn_c[cell] => acrn_m[cell]
 - id: R00141
@@ -458,7 +456,6 @@
     + pi_c[cell]
 - id: R00249
   equation: asnL_c[cell] + H2O_c[cell] => aspL_c[cell] + nh4_c[cell]
-- id: R00250
 - id: R00251
   equation: aspL_c[cell] + atp_c[cell] + glnL_c[cell] + H2O_c[cell] => amp_c[cell]
     + asnL_c[cell] + gluL_c[cell] + h_c[cell] + ppi_c[cell]
@@ -874,7 +871,6 @@
   equation: akg_x[cell] + e4hglu_x[cell] => a_4H2Oglt_x[cell] + gluL_x[cell]
 - id: R00443
   equation: a_2pg_c[cell] <=> H2O_c[cell] + pep_c[cell]
-- id: R00444
 - id: R00445
   equation: ergst_c[cell] + udpg_c[cell] => ergst3glc_c[cell] + h_c[cell] + udp_c[cell]
 - id: R00447
@@ -2423,12 +2419,10 @@
   equation: H2O2_n[cell] + TRDrd_n[cell] => (2) H2O_n[cell] + TRDox_n[cell]
 - id: R01146
   equation: H2O2_x[cell] + TRDrd_x[cell] <=> (2) H2O_x[cell] + TRDox_x[cell]
-- id: R01147
 - id: R01148
   equation: => h_c[cell] + thymd_c[cell]
 - id: R01149
   equation: H2O_c[cell] + thmmp_c[cell] => pi_c[cell] + thm_c[cell]
-- id: R01150
 - id: R01151
   equation: thmpp_c[cell] => thmpp_m[cell]
 - id: R01152
@@ -2663,7 +2657,6 @@
   equation: atp_n[cell] + ptd1ino_n[cell] => adp_n[cell] + h_n[cell] + ptd4ino_n[cell]
 - id: R01263
   equation: cdpdag_c[cell] + inost_c[cell] => cmp_c[cell] + h_c[cell] + ptd1ino_c[cell]
-- id: R01264
 - id: R01265
   equation:
     reversible: false

--- a/sbml/PpuMBEL1071/reactions.yaml
+++ b/sbml/PpuMBEL1071/reactions.yaml
@@ -143,8 +143,6 @@
   equation: K6PG[cell] + NADPH[cell] => D6PGC[cell] + NADP[cell]
 - id: ED_kguK
   equation: KDG[cell] + ATP[cell] => K6PG[cell] + ADP[cell]
-- id: EXT_gad
-- id: EXT_gcd
 - id: FAS_B
   equation: ACACP[cell] + MALACP[cell] + (2) NADPH[cell] => (2) NADP[cell] + C040ACP[cell]
     + CO2[cell] + ACP[cell]

--- a/sbml/SpoMBEL1693/reactions.yaml
+++ b/sbml/SpoMBEL1693/reactions.yaml
@@ -48,21 +48,15 @@
 - id: RXN00016
   name: RXN00016
   equation: mant_r[cell] + H2O_r[cell] => gal_r[cell] + melib_r[cell]
-- id: RXN00017
-  name: RXN00017
 - id: RXN00018
   name: RXN00018
   equation: raffin_c[cell] + H2O_c[cell] => melib_c[cell] + fru_c[cell]
-- id: RXN00019
-  name: RXN00019
 - id: RXN00020
   name: RXN00020
   equation: sta_c[cell] + H2O_c[cell] => mant_c[cell] + fru_c[cell]
 - id: RXN00021
   name: RXN00021
   equation: sta_r[cell] + H2O_r[cell] => raffin_r[cell] + gal_r[cell]
-- id: RXN00022
-  name: RXN00022
 - id: RXN00023
   name: RXN00023
   equation: urea_c[cell] + H2O_c[cell] => CO2_c[cell] + (2) NH4_c[cell]
@@ -133,8 +127,6 @@
 - id: RXN00043
   name: RXN00043
   equation: GALI_r[cell] + H2O_r[cell] <=> inost_r[cell] + gal_r[cell]
-- id: RXN00044
-  name: RXN00044
 - id: RXN00045
   name: RXN00045
   equation: glycogen_c[cell] + H2O_c[cell] => dext_c[cell]
@@ -208,8 +200,6 @@
 - id: RXN00065
   name: RXN00065
   equation: emp_r[cell] + H2O_r[cell] <=> man_r[cell] + gal_r[cell]
-- id: RXN00066
-  name: RXN00066
 - id: RXN00067
   name: RXN00067
   equation: (9) H_r[cell] + (3) MALCoA_r[cell] + (6) NADPH_r[cell] + C180_r[cell]
@@ -224,8 +214,6 @@
 - id: RXN00070
   name: RXN00070
   equation: ggl_r[cell] + H2O_r[cell] <=> gal_r[cell] + glyc_r[cell]
-- id: RXN00071
-  name: RXN00071
 - id: RXN00072
   name: RXN00072
   equation: glycogen_g[cell] + H2O_g[cell] => GLC_g[cell]
@@ -263,8 +251,6 @@
 - id: RXN00083
   name: RXN00083
   equation: melt_r[cell] + H2O_r[cell] <=> sbtD_r[cell] + gal_r[cell]
-- id: RXN00084
-  name: RXN00084
 - id: RXN00085
   name: RXN00085
   equation: H2O_m[cell] + (0.01) mipc124_m[cell] => cer124_m[cell] + H_m[cell] +
@@ -382,8 +368,6 @@
 - id: RXN00115
   name: RXN00115
   equation: a_3mob_m[cell] + H2O_m[cell] + mlTHF_m[cell] => a_2dhp_m[cell] + THF_m[cell]
-- id: RXN00116
-  name: RXN00116
 - id: RXN00117
   name: RXN00117
   equation: GDP_r[cell] + H2O_r[cell] => GMP_r[cell] + H_r[cell] + Pi_r[cell]
@@ -416,8 +400,6 @@
 - id: RXN00126
   name: RXN00126
   equation: dgala_r[cell] + H2O_r[cell] => gala_r[cell] + gal_r[cell]
-- id: RXN00127
-  name: RXN00127
 - id: RXN00128
   name: RXN00128
   equation: rnam_c[cell] + H2O_c[cell] => ncam_c[cell] + ribD_c[cell]
@@ -519,8 +501,6 @@
 - id: RXN00160
   name: RXN00160
   equation: a_13BDglcn_c[cell] + H2O_c[cell] => GLC_c[cell]
-- id: RXN00161
-  name: RXN00161
 - id: RXN00162
   name: RXN00162
   equation: UDPg_c[cell] => a_13ADglcn_c[cell] + H_c[cell] + UDP_c[cell]
@@ -792,8 +772,6 @@
 - id: RXN00257
   name: RXN00257
   equation: acg5sa_n[cell] + GLU_n[cell] => acorn_n[cell] + AKG_n[cell]
-- id: RXN00258
-  name: RXN00258
 - id: RXN00259
   name: RXN00259
   equation: fmn_g[cell] + H2O_g[cell] => Pi_g[cell] + ribflv_g[cell]
@@ -1237,8 +1215,6 @@
 - id: RXN00403
   name: RXN00403
   equation: ASN_c[cell] + H2O_c[cell] => ASP_c[cell] + NH4_c[cell]
-- id: RXN00404
-  name: RXN00404
 - id: RXN00405
   name: RXN00405
   equation: ASP_c[cell] + ATP_c[cell] + GLN_c[cell] + H2O_c[cell] => AMP_c[cell]
@@ -4128,8 +4104,6 @@
 - id: RXN01346
   name: RXN01346
   equation: oh1_m[cell] + Pi_c[cell] <=> oh1_c[cell] + Pi_m[cell]
-- id: RXN01347
-  name: RXN01347
 - id: RXN01348
   name: RXN01348
   equation:
@@ -4169,8 +4143,6 @@
     - id: C140_c
       compartment: cell
       value: 0.1
-- id: RXN01349
-  name: RXN01349
 - id: RXN01350
   name: RXN01350
   equation: H2O_c[cell] + pc_c[cell] => CHOL_c[cell] + H_c[cell] + pa_c[cell]
@@ -4500,8 +4472,6 @@
 - id: RXN01456
   name: RXN01456
   equation: raffin_r[cell] + H2O_r[cell] => gal_r[cell] + sucr_r[cell]
-- id: RXN01457
-  name: RXN01457
 - id: RXN01458
   name: RXN01458
   equation: ATP_c[cell] + ribflv_c[cell] => ADP_c[cell] + fmn_c[cell] + H_c[cell]
@@ -4758,8 +4728,6 @@
   name: RXN01546
   equation: ATP_m[cell] + CoA_m[cell] + SUCC_m[cell] <=> ADP_m[cell] + Pi_m[cell]
     + sucCoA_m[cell]
-- id: RXN01547
-  name: RXN01547
 - id: RXN01548
   name: RXN01548
   equation: => H_c[cell] + sucr_c[cell]
@@ -4847,16 +4815,12 @@
 - id: RXN01563
   name: RXN01563
   equation: H2O2_x[cell] + trdrd_x[cell] <=> (2) H2O_x[cell] + trdox_x[cell]
-- id: RXN01564
-  name: RXN01564
 - id: RXN01565
   name: RXN01565
   equation: => H_c[cell] + thymd_c[cell]
 - id: RXN01566
   name: RXN01566
   equation: H2O_g[cell] + thmmp_g[cell] => Pi_g[cell] + thm_g[cell]
-- id: RXN01567
-  name: RXN01567
 - id: RXN01568
   name: RXN01568
   equation: H2O_r[cell] + thmmp_r[cell] => Pi_r[cell] + thm_r[cell]


### PR DESCRIPTION
With the recent model reimport some reaction entries were retained even though no valid equation was defined for those entries. This pull request removed those entries. `psamm-import` will be updated to remove those entries automatically in the future.