### PR TITLE
fix-iCA1273

### DIFF
--- a/sbml/iCA1273/model.yaml
+++ b/sbml/iCA1273/model.yaml
@@ -11,7 +11,7 @@ compartments:
   adjacent_to:
   - Cytosol
   - periplasm
-- id: Periplasm
+- id: periplasm
 compounds:
 - include: compounds.yaml
 reactions:


### PR DESCRIPTION
Changed "Periplasm" to "periplasm" to comply with capitalization in the rest of the model